### PR TITLE
fix awsconfig result processing by resource types

### DIFF
--- a/pkg/cloudig/awsconfig.go
+++ b/pkg/cloudig/awsconfig.go
@@ -63,13 +63,19 @@ func processConfigResults(results map[string][]*configservice.EvaluationResult, 
 		finding.RuleName = name
 		finding.Status = configservice.ComplianceTypeNonCompliant // keeping this for backword compatibility
 		finding.Comments = getComments(comments, finding.AccountID, findingTypeAWSConfig, finding.RuleName)
-		flaggedResources := []string{}
+		finding.FlaggedResources = map[string][]string{}
+
 		for _, evaluationResult := range result {
-			if aws.StringValue(evaluationResult.ComplianceType) != configservice.ComplianceTypeCompliant {
-				flaggedResources = append(flaggedResources, aws.StringValue(evaluationResult.EvaluationResultIdentifier.EvaluationResultQualifier.ResourceId))
+			if aws.StringValue(evaluationResult.ComplianceType) == configservice.ComplianceTypeCompliant {
+				continue
 			}
+
+			resType := aws.StringValue(evaluationResult.EvaluationResultIdentifier.EvaluationResultQualifier.ResourceType)
+			resId := aws.StringValue(evaluationResult.EvaluationResultIdentifier.EvaluationResultQualifier.ResourceId)
+
+			finding.FlaggedResources[resType] = append(finding.FlaggedResources[resType], resId)
 		}
-		finding.FlaggedResources = map[string][]string{aws.StringValue(result[0].EvaluationResultIdentifier.EvaluationResultQualifier.ResourceType): flaggedResources}
+
 		findings = append(findings, finding)
 	}
 

--- a/pkg/cloudig/awsconfig.go
+++ b/pkg/cloudig/awsconfig.go
@@ -19,7 +19,7 @@ type ConfigReport struct {
 type configFinding struct {
 	AccountID string `json:"accountId"`
 	RuleName  string `json:"ruleName"`
-	//Description      string
+	// Description      string
 	Status           string              `json:"status"`
 	FlaggedResources map[string][]string `json:"flaggedResources"`
 	Comments         string              `json:"comments"`

--- a/pkg/cloudig/output_test.go
+++ b/pkg/cloudig/output_test.go
@@ -195,7 +195,7 @@ func TestAWSConfigTableOutput(t *testing.T) {
 						AccountID:        "111111111111",
 						RuleName:         "ALL_OPEN_INBOUND_PORTS_SECURITY_GROUP_CHECK",
 						Status:           "NON_COMPLIANT",
-						FlaggedResources: map[string][]string{"AWS::EC2::SecurityGroup": {"sg-00003"}},
+						FlaggedResources: map[string][]string{"AWS::EC2::SecurityGroup": {"sg-00003"}, "AWS::EC2::Instance": {"i-00003"}},
 						Comments:         "NEW_FINDING",
 					},
 					{
@@ -211,6 +211,8 @@ func TestAWSConfigTableOutput(t *testing.T) {
 			expectedOutput: `|  ACCOUNT ID  |                    NAME                     |          FLAGGED RESOURCES          |  COMMENTS   |
 |--------------|---------------------------------------------|-------------------------------------|-------------|
 | 111111111111 | ALL_OPEN_INBOUND_PORTS_SECURITY_GROUP_CHECK | Resource Type:                      | NEW_FINDING |
+|              |                                             | AWS::EC2::Instance                  |             |
+|              |                                             | i-00003 Resource Type:              |             |
 |              |                                             | AWS::EC2::SecurityGroup             |             |
 |              |                                             | sg-00003                            |             |
 | 111111111111 | S3_BUCKET_LOGGING_ENABLED                   | Resource Type: AWS::S3::Bucket      | NEW_FINDING |


### PR DESCRIPTION
## Proposed changes
Fix resource type grouping for AWS Config. Current implementation pushes all resources under the first resource type.

## Issues for these changes
-

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

- [x] I have filled out this PR template
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (`README.md`, `CHANGELOG.md`, etc. - if appropriate)

## Dependencies and Blockers
none

## Relevant Links
-

## Further comments
Current results:
```
{
  "findings": [
    {
      "accountId": "0000000000000",
      "ruleName": "required-tags",
      "status": "NON_COMPLIANT",
      "flaggedResources": {
        "AWS::DynamoDB::Table": [1,2,3,4,5,6]
      }
}
```
After fix:
```
{
  "findings": [
    {
      "accountId": "0000000000000",
      "ruleName": "required-tags",
      "status": "NON_COMPLIANT",
      "flaggedResources": {
        "AWS::ACM::Certificate": [1,2,3],
        "AWS::AutoScaling::AutoScalingGroup": [1,2,3],
        "AWS::CloudFormation::Stack": [1,2,3],
        ...
        ],
    }
}
```